### PR TITLE
Change ULONG_PTR to a 32-bit int for non-x86_64 builds

### DIFF
--- a/src/win32/c.zig
+++ b/src/win32/c.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 
 pub const va_list = [*c]u8;
 pub extern fn __va_start(arg0: [*c]([*c]u8), ...) void;
@@ -22,7 +23,7 @@ pub const enum__EXCEPTION_DISPOSITION = extern enum {
 pub const EXCEPTION_DISPOSITION = enum__EXCEPTION_DISPOSITION;
 pub const DWORD = c_ulong;
 pub const PVOID = ?*c_void;
-pub const ULONG_PTR = c_ulonglong;
+pub const ULONG_PTR = (if (builtin.arch == .x86_64) c_ulonglong else c_ulong);
 pub const struct__EXCEPTION_RECORD = extern struct {
     ExceptionCode: DWORD,
     ExceptionFlags: DWORD,

--- a/src/win32/lean_and_mean.zig
+++ b/src/win32/lean_and_mean.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 
 pub const va_list = [*c]u8;
 extern fn __va_start(arg0: [*c]([*c]u8), ...) void;
@@ -22,7 +23,7 @@ pub const enum__EXCEPTION_DISPOSITION = extern enum {
 pub const EXCEPTION_DISPOSITION = enum__EXCEPTION_DISPOSITION;
 pub const DWORD = c_ulong;
 pub const PVOID = ?*c_void;
-pub const ULONG_PTR = c_ulonglong;
+pub const ULONG_PTR = (if (builtin.arch == .x86_64) c_ulonglong else c_ulong);
 pub const struct__EXCEPTION_RECORD = extern struct {
     ExceptionCode: DWORD,
     ExceptionFlags: DWORD,


### PR DESCRIPTION
In BaseTsd.h this is defined as

```c
#if defined(_WIN64)
 typedef __int64 LONG_PTR; 
#else
 typedef long LONG_PTR;
#endif
```

https://docs.microsoft.com/en-us/windows/win32/winprog/windows-data-types#LONG_PTR