### PR TITLE
Remove variadic args from the PROC callback types

### DIFF
--- a/src/win32/c.zig
+++ b/src/win32/c.zig
@@ -7261,9 +7261,9 @@ pub const HGLOBAL = HANDLE;
 pub const HLOCAL = HANDLE;
 pub const GLOBALHANDLE = HANDLE;
 pub const LOCALHANDLE = HANDLE;
-pub const FARPROC = ?fn (...) callconv(std.os.windows.WINAPI) INT_PTR;
-pub const NEARPROC = ?fn (...) callconv(std.os.windows.WINAPI) INT_PTR;
-pub const PROC = ?fn (...) callconv(std.os.windows.WINAPI) INT_PTR;
+pub const FARPROC = [*c]fn () callconv(std.os.windows.WINAPI) INT_PTR;
+pub const NEARPROC = [*c]fn () callconv(std.os.windows.WINAPI) INT_PTR;
+pub const PROC = [*c]fn () callconv(std.os.windows.WINAPI) INT_PTR;
 pub const ATOM = WORD;
 pub const struct_HKEY__ = extern struct {
     unused: c_int,


### PR DESCRIPTION
These changes are copied from `lean_and_mean.zig`

The main reason for doing this is for i386 builds, where Zig defines `std.os.windows.WINAPI` as `Stdcall` rather than `C`, and Zig doesn't support variadic args unless the calling convention is `C`.

I completely appreciate there could be a reason I'm missing as to why these are variadic though!